### PR TITLE
Add ESPN Cricinfo scraping example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# hellosite
+# HelloSite Examples
+
+This repository demonstrates various experiments with automated web tools. The `scraper` directory contains a proof-of-concept script for collecting cricket records from ESPN Cricinfo using Prisma. See `SCRAPER_GUIDE.md` for details.

--- a/SCRAPER_GUIDE.md
+++ b/SCRAPER_GUIDE.md
@@ -1,0 +1,33 @@
+# ESPN Cricinfo Records Scraper
+
+This example demonstrates a scalable approach for collecting cricket records from the ESPN Cricinfo website. The goal is to fetch the **Test Matches** records section and store the tables in a PostgreSQL database using Prisma.
+
+## Overview
+1. **Prisma Schema** – located in `prisma/schema.prisma`. It defines two models:
+   - `RecordCategory` – represents each record category on the site (e.g. "Most runs", "Highest averages").
+   - `Record` – stores individual rows from the tables. The contents of each row are stored as JSON so that different table structures can be supported.
+2. **Scraper** – `scraper/espnScraper.js` fetches the main Test Matches page, collects the category links and then processes each table. Data is inserted via the Prisma client.
+
+This approach is independent of the exact table layout and can be extended to any other page on `espncricinfo.com/records`.
+
+## Running
+```bash
+# install dependencies (requires network access)
+npm install
+
+# generate prisma client
+npx prisma generate
+
+# start scraping
+node scraper/espnScraper.js
+```
+
+`DATABASE_URL` should be set in the environment or in a `.env` file so Prisma can connect to PostgreSQL.
+
+The scraper uses Axios and Cheerio to parse HTML. If ESPN Cricinfo exposes a JSON API, the `fetchHtml` function can be replaced to call the API endpoints, which would reduce the amount of HTML parsing and speed up the process.
+
+```
+DATABASE_URL="postgresql://user:password@localhost:5432/hellosite"
+```
+
+This is a minimal example for demonstration purposes. In a real project, you can integrate the Prisma client into a NestJS backend and expose the data through an API, while Next.js can provide a frontend for browsing the stored records.

--- a/nest-app/src/app.module.ts
+++ b/nest-app/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { RecordsModule } from './records/records.module';
+
+@Module({
+  imports: [RecordsModule],
+})
+export class AppModule {}

--- a/nest-app/src/main.ts
+++ b/nest-app/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/nest-app/src/records/records.controller.ts
+++ b/nest-app/src/records/records.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { RecordsService } from './records.service';
+
+@Controller('records')
+export class RecordsController {
+  constructor(private readonly service: RecordsService) {}
+
+  @Get()
+  async getAll() {
+    return this.service.categories();
+  }
+}

--- a/nest-app/src/records/records.module.ts
+++ b/nest-app/src/records/records.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RecordsService } from './records.service';
+import { RecordsController } from './records.controller';
+
+@Module({
+  controllers: [RecordsController],
+  providers: [RecordsService],
+})
+export class RecordsModule {}

--- a/nest-app/src/records/records.service.ts
+++ b/nest-app/src/records/records.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class RecordsService {
+  private prisma = new PrismaClient();
+
+  async categories() {
+    return this.prisma.recordCategory.findMany({ include: { records: true } });
+  }
+}

--- a/nest-app/tsconfig.json
+++ b/nest-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es2020",
+    "sourceMap": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/next-app/pages/api/records.ts
+++ b/next-app/pages/api/records.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const data = await prisma.recordCategory.findMany({ include: { records: true } });
+  res.status(200).json(data);
+}

--- a/next-app/pages/index.tsx
+++ b/next-app/pages/index.tsx
@@ -1,0 +1,22 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function Home() {
+  const { data, error } = useSWR('/api/records', fetcher);
+
+  if (error) return <div>Failed to load</div>;
+  if (!data) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Cricket Records</h1>
+      {data.map((cat: any) => (
+        <div key={cat.id}>
+          <h3>{cat.name}</h3>
+          <pre>{JSON.stringify(cat.records, null, 2)}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
   "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "scrape": "node scraper/espnScraper.js"
   },
   "dependencies": {
     "ai": "^4.3.15",
+    "@prisma/client": "^5.9.1",
     "axios": "^1.8.4",
     "cheerio": "^1.0.0",
     "child_process": "^1.0.2",
@@ -28,6 +30,9 @@
     "simple-git": "^3.27.0",
     "telegraf": "^4.16.3",
     "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.9.1"
   },
   "author": "",
   "license": "ISC"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,28 @@
+// Prisma schema for ESPN Cricinfo records
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model RecordCategory {
+  id        Int      @id @default(autoincrement())
+  name      String
+  url       String   @unique
+  records   Record[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Record {
+  id         Int            @id @default(autoincrement())
+  category   RecordCategory @relation(fields: [categoryId], references: [id])
+  categoryId Int
+  data       Json
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}

--- a/scraper/espnScraper.js
+++ b/scraper/espnScraper.js
@@ -1,0 +1,81 @@
+import axios from 'axios';
+import cheerio from 'cheerio';
+import { PrismaClient } from '@prisma/client';
+
+const BASE_URL = 'https://www.espncricinfo.com';
+const TEST_MATCHES_URL = `${BASE_URL}/records/format/test-matches-1`;
+
+const prisma = new PrismaClient();
+
+async function fetchHtml(url) {
+  const { data } = await axios.get(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+  return data;
+}
+
+async function parseCategories() {
+  const html = await fetchHtml(TEST_MATCHES_URL);
+  const $ = cheerio.load(html);
+  const categories = [];
+  $('a.ds-block.ds-py-3').each((_, el) => {
+    const name = $(el).find('h5').text().trim();
+    const href = $(el).attr('href');
+    if (href) {
+      categories.push({ name, url: BASE_URL + href });
+    }
+  });
+  return categories;
+}
+
+async function saveCategory(cat) {
+  return prisma.recordCategory.upsert({
+    where: { url: cat.url },
+    update: { name: cat.name },
+    create: { name: cat.name, url: cat.url },
+  });
+}
+
+async function parseTable(pageUrl) {
+  const html = await fetchHtml(pageUrl);
+  const $ = cheerio.load(html);
+  const records = [];
+
+  $('table').each((_, table) => {
+    const headers = [];
+    $(table)
+      .find('thead tr th')
+      .each((_, th) => headers.push($(th).text().trim()));
+
+    $(table)
+      .find('tbody tr')
+      .each((_, row) => {
+        const entry = {};
+        $(row)
+          .find('td')
+          .each((i, cell) => {
+            const header = headers[i] || `col_${i}`;
+            entry[header] = $(cell).text().trim();
+          });
+        records.push(entry);
+      });
+  });
+  return records;
+}
+
+async function scrape() {
+  const cats = await parseCategories();
+  for (const cat of cats) {
+    const category = await saveCategory(cat);
+    console.log(`Saved category: ${category.name}`);
+    const rows = await parseTable(cat.url);
+    for (const row of rows) {
+      await prisma.record.create({
+        data: { categoryId: category.id, data: row },
+      });
+    }
+    console.log(`Added ${rows.length} records for ${category.name}`);
+  }
+}
+
+scrape()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary
- create Prisma schema for cricket records
- add scraper example that parses ESPN Cricinfo tables
- document scraping approach
- add NestJS and Next.js demo code
- update package.json with Prisma dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870ff316c788324ab247ff2caa1e24d