### PR TITLE
Add Prisma integration to scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# hellosite
+# HelloSite
+
+This repository contains multiple utilities. The `cricinfo-nest` folder provides a Nest.js and Prisma based scraper for ESPN Cricinfo records tables.
+
+Refer to `cricinfo-nest/README.md` for setup and usage instructions.

--- a/cricinfo-nest/README.md
+++ b/cricinfo-nest/README.md
@@ -1,0 +1,28 @@
+# Cricinfo Parser
+
+This module uses Nest.js together with Prisma to recursively scrape tables from `https://www.espncricinfo.com/records` and store them in PostgreSQL.
+
+## Setup
+
+1. Configure a PostgreSQL database and set the `DATABASE_URL` environment variable. Example:
+
+   ```
+   DATABASE_URL="postgresql://postgres:postgres@localhost:5432/cricinfo"
+   ```
+
+2. Install dependencies, generate the Prisma client and build the project:
+
+```bash
+npm install
+npx prisma generate
+npx prisma migrate deploy
+npm run build
+```
+
+3. Run the scraper:
+
+```bash
+npm start
+```
+
+Tables are stored generically so that any table structure can be captured. Pages and tables are related through `page_id` and `parent_id` fields, enabling navigation of the hierarchy.

--- a/cricinfo-nest/package.json
+++ b/cricinfo-nest/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "cricinfo-parser",
+  "version": "1.0.0",
+  "description": "Nest.js service to scrape ESPN Cricinfo tables and store them in PostgreSQL",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "build": "tsc",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/axios": "^2.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "axios": "^1.8.4",
+    "cheerio": "^1.0.0",
+    "@prisma/client": "^5.12.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "prisma": "^5.12.1"
+  }
+}

--- a/cricinfo-nest/prisma/schema.prisma
+++ b/cricinfo-nest/prisma/schema.prisma
@@ -1,0 +1,26 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Page {
+  id        Int     @id @default(autoincrement())
+  url       String  @unique
+  parentId  Int?
+  parent    Page?   @relation("PageChildren", fields: [parentId], references: [id])
+  children  Page[]  @relation("PageChildren")
+  tables    Table[]
+}
+
+model Table {
+  id      Int     @id @default(autoincrement())
+  pageId  Int
+  page    Page    @relation(fields: [pageId], references: [id])
+  title   String?
+  headers Json?
+  rows    Json?
+}

--- a/cricinfo-nest/src/app.module.ts
+++ b/cricinfo-nest/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { PrismaService } from './prisma.service';
+import { ScraperService } from './scraper.service';
+
+@Module({
+  imports: [HttpModule],
+  providers: [PrismaService, ScraperService],
+})
+export class AppModule {}

--- a/cricinfo-nest/src/main.ts
+++ b/cricinfo-nest/src/main.ts
@@ -1,0 +1,12 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ScraperService } from './scraper.service';
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const scraper = app.get(ScraperService);
+  await scraper.scrape('https://www.espncricinfo.com/records');
+  await app.close();
+}
+
+bootstrap();

--- a/cricinfo-nest/src/prisma.service.ts
+++ b/cricinfo-nest/src/prisma.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/cricinfo-nest/src/scraper.service.ts
+++ b/cricinfo-nest/src/scraper.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import axios from 'axios';
+import * as cheerio from 'cheerio';
+import { PrismaService } from './prisma.service';
+
+@Injectable()
+export class ScraperService {
+  private readonly logger = new Logger(ScraperService.name);
+  private visited = new Set<string>();
+
+  constructor(private db: PrismaService) {}
+
+  async scrape(url: string, parentId: number | null = null) {
+    if (this.visited.has(url)) {
+      return;
+    }
+    this.visited.add(url);
+    this.logger.log(`Scraping ${url}`);
+
+    const page = await this.db.page.upsert({
+      where: { url },
+      update: { parentId },
+      create: { url, parentId },
+    });
+    const pageId = page.id;
+
+    try {
+      const { data } = await axios.get(url);
+      const $ = cheerio.load(data);
+
+      const tables = $('table');
+      tables.each(async (_, elem) => {
+        const title = $(elem).prev('h2, h3').first().text() || null;
+        const headers: string[] = [];
+        $(elem)
+          .find('thead tr th')
+          .each((_, th) => headers.push($(th).text().trim()));
+        const rows: any[] = [];
+        $(elem)
+          .find('tbody tr')
+          .each((_, tr) => {
+            const row: any = {};
+            $(tr)
+              .find('td')
+              .each((i, td) => {
+                const header = headers[i] || `col${i + 1}`;
+                row[header] = $(td).text().trim();
+              });
+            rows.push(row);
+          });
+        await this.db.table.create({
+          data: {
+            pageId,
+            title,
+            headers,
+            rows,
+          },
+        });
+      });
+
+      // find links to other pages under the same domain
+      const links = $('a')
+        .map((_, a) => $(a).attr('href'))
+        .get()
+        .filter((href) => href && href.startsWith('/records'));
+
+      for (const link of links) {
+        const absolute = new URL(link, url).toString();
+        await this.scrape(absolute, pageId);
+      }
+    } catch (e) {
+      this.logger.error(`Failed to scrape ${url}: ${e}`);
+    }
+  }
+}

--- a/cricinfo-nest/tsconfig.json
+++ b/cricinfo-nest/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "target": "ES2020",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- switch scraper module to Prisma
- update README with Prisma usage
- replace pg DatabaseService with PrismaService
- adjust scraper logic to use Prisma ORM

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd cricinfo-nest && npm test` *(prints "No tests specified")*

------
https://chatgpt.com/codex/tasks/task_e_687104d97540832488d421626c684e7c